### PR TITLE
Add HTTP request as well as response logging

### DIFF
--- a/CRUDEFutures/CRUDERequest.swift
+++ b/CRUDEFutures/CRUDERequest.swift
@@ -24,7 +24,7 @@ import BrightFutures
 public struct CRUDERequest {
 
     public var urlString: URLStringConvertible
-    public var parameters: [String: AnyObject]? = nil
+    public var parameters: HTTPQueryParameters = nil
     public var headers: [String: String]? = nil
     private var request: Request? = nil
 
@@ -37,7 +37,7 @@ public struct CRUDERequest {
      - parameter parameters:  Optionally include query or attribute items.
      - parameter headers:    Provide if the headers for this request differ from those used by CRUDE. If headers are not provided, the request will default to the headers set when CRUDE was configured.
      */
-    public init(urlString: URLStringConvertible, parameters: [String: AnyObject]? = nil, headers: [String: String]? = nil) {
+    public init(urlString: URLStringConvertible, parameters: HTTPQueryParameters = nil, headers: [String: String]? = nil) {
         self.urlString = urlString
         self.parameters = parameters
         self.headers = headers
@@ -60,10 +60,12 @@ public struct CRUDERequest {
             : .URLEncodedInURL
         let headers = self.headers ?? CRUDE.headers
 
+        _requestLog?(requestType, urlString.URLString, parameters, headers)
+
         request = Alamofire.request(requestType.amMethod, urlString, parameters: parameters, encoding: encoding, headers: headers)
         request!.responseJSON { network in
             UIApplication.sharedApplication().networkActivityIndicatorVisible = false
-            _logResult?(requestType, network)
+            _responseLog?(network)
 
             guard let response = network.response else {
                 promise.failure(CRUDE.errorFromResponse(network))

--- a/README.md
+++ b/README.md
@@ -53,25 +53,39 @@ For example:
 CRUDE.configure(baseURL: "https://mysite.com/api", headers: kDefaultHeaders)
 ```
 
-If you would like CRUDE to do some kind of logging whenever API calls are made, you can provide a `CRUDELog` block. This can be done through a variable:
+If you would like CRUDE to do some kind of logging whenever API calls are made, you can provide a block to be run pre-request:
 
 ```swift
-let myLogger: CRUDELog = { method, response in
-    print("CRUDE request \(method) \(response.request?.URLString)")
+let httpRequestLogger: CRUDERequestLog = { method, path, params, headers in
+    print("CRUDE request \(method) \(path)")
+    if let params = params {
+        for (name, value) in params {
+            print("\(name)=\(value)")
+        }
+    }
+    print("HTTP Headers:")
+    for (name, value) in headers {
+        print("\(name): \(value)")
+    }
 }
-
-CRUDE.configure(baseURL: "https://mysite.com/api", headers: kDefaultHeaders, requestLoggingBlock: myLogger)
+CRUDE.setRequestLoggingBlock(httpRequestLogger)
 ```
 
-...or by providing the block at the end of your configure call:
+And to log responses:
 
 ```swift
-CRUDE.configure(baseURL: "https://mysite.com/api", headers: kDefaultHeaders) { method, response in
-    print("CRUDE request \(method) \(response.request?.URLString)")
+let httpResponseLogger: CRUDEResponseLog = { network in
+    switch network.result {
+    case .Success:
+        let method = network.request?.HTTPMethod ?? "UNKNOWN"
+        let urlString = network.request?.URLString ?? "unknown"
+        print("\(network.response!.statusCode) from \(method) \(urlString)")
+    case .Failure(let error):
+        print("CRUDE FAILURE: \(error.localizedDescription)")
+    }
 }
+CRUDE.setResponseLoggingBlock(httpResponseLogger)
 ```
-
-If you don't provide a logging block, a default logger will be used. The default logger only prints to the console in a DEBUG build. If you don't want CRUDE to print to the console, you can turn off the default logger by setting `CRUDE.shouldUseDefaultLogger` to `false`.
 
 ## Mappable Models
 


### PR DESCRIPTION
- create type aliases for headers and params
- call log block before the request
- call log block after response
- remove default logger, add log examples to README

Not vital for the OrderUp app. I'm using it locally to debug, but I don't need to upgrade the app to use this code until you've reviewed it and are happy with it.
